### PR TITLE
add support for mutations without input

### DIFF
--- a/integration/schema/schema.graphql
+++ b/integration/schema/schema.graphql
@@ -17,6 +17,7 @@ type Query {
 
 type Mutation {
   saveAuthor(input: AuthorInput!): SaveAuthorResult!
+  noInputMutation: Boolean
 }
 
 type SaveAuthorResult {

--- a/integration/src/generated/graphql-types.ts
+++ b/integration/src/generated/graphql-types.ts
@@ -12,6 +12,7 @@ export interface Resolvers {
 }
 
 export interface MutationResolvers {
+  noInputMutation: Resolver<{}, {}, Boolean | null | undefined>;
   saveAuthor: Resolver<{}, MutationSaveAuthorArgs, SaveAuthorResult>;
   saveBook: Resolver<{}, MutationSaveBookArgs, SaveBookResult>;
 }

--- a/integration/src/resolvers/mutations.ts
+++ b/integration/src/resolvers/mutations.ts
@@ -1,10 +1,12 @@
 import { MutationResolvers } from "@src/generated/graphql-types";
+import { noInputMutation } from "@src/resolvers/mutations/noInputMutationResolver";
 import { saveAuthor } from "@src/resolvers/mutations/saveAuthorResolver";
 import { saveBook } from "@src/resolvers/mutations/books/saveBookResolver";
 
 // This file is auto-generated
 
 export const mutationResolvers: MutationResolvers = {
+  ...noInputMutation,
   ...saveAuthor,
   ...saveBook,
 };

--- a/integration/src/resolvers/mutations/noInputMutationResolver.test.ts
+++ b/integration/src/resolvers/mutations/noInputMutationResolver.test.ts
@@ -1,0 +1,15 @@
+import { Context } from "@src/context";
+import { run } from "@src/resolvers/testUtils";
+import { noInputMutation } from "@src/resolvers/mutations/noInputMutationResolver";
+
+describe("noInputMutation", () => {
+  it("handles this business case", () => {
+    fail();
+  });
+});
+
+async function runNoInputMutation(ctx: Context, inputFn: () => void) {
+  return await run(ctx, async () => {
+    return noInputMutation.noInputMutation({}, { input: inputFn() }, ctx, undefined!);
+  });
+}

--- a/integration/src/resolvers/mutations/noInputMutationResolver.ts
+++ b/integration/src/resolvers/mutations/noInputMutationResolver.ts
@@ -1,0 +1,7 @@
+import { MutationResolvers } from "@src/generated/graphql-types";
+
+export const noInputMutation: Pick<MutationResolvers, "noInputMutation"> = {
+  async noInputMutation(root, args, ctx) {
+    throw new Error("not implemented");
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,10 +121,9 @@ async function maybeGenerateMutationScaffolding(mutation: GraphQLObjectType): Pr
     `;
 
     const inputType = getInputType(field);
-    if (!inputType) {
-      return;
-    }
-    const inputImp = imp(`${inputType.name}@@src/generated/graphql-types`);
+
+    // if no inputType then make inputImp void
+    const inputImp = inputType ? imp(`${inputType.name}@@src/generated/graphql-types`) : "void";
 
     const maybeSubDir = subDirectory(cwd, field);
     const modulePath = `${baseDir}/mutations/${maybeSubDir}${name}Resolver`;
@@ -197,10 +196,12 @@ async function writeBarrelFile(constName: string, constType: SymbolSpec, filePat
 
 /** Assumes the mutation has a single `Input`-style parameter, which should be non-null. */
 function getInputType(field: GraphQLField<any, any>): GraphQLInputObjectType | undefined {
-  if (field.args[0].type instanceof GraphQLNonNull) {
-    return (field.args[0].type.ofType as any) as GraphQLInputObjectType;
-  } else if (field.args[0].type instanceof GraphQLInputObjectType) {
-    return field.args[0].type;
+  if (field.args.length > 0) {
+    if (field.args[0].type instanceof GraphQLNonNull) {
+      return (field.args[0].type.ofType as any) as GraphQLInputObjectType;
+    } else if (field.args[0].type instanceof GraphQLInputObjectType) {
+      return field.args[0].type;
+    }
   }
   return undefined;
 }


### PR DESCRIPTION
Wanted to support mutations without inputs.  e.g.
```
type Mutation {
  myMutationWithoutInput: Boolean
}
```

LMK thoughts 