### PR TITLE
fix: exclude integration files from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 /src
 /.idea
 /.circleci
+/integration


### PR DESCRIPTION
Previously:

```
 ~/code/homebound/graphql-typescript-resolver-scaffolding   main  npm pack
npm notice
npm notice 📦  @homebound/graphql-typescript-resolver-scaffolding@1.0.0-bump
npm notice === Tarball Contents ===
npm notice 9B     .nvmrc
npm notice 65B    .prettierrc.js
npm notice 49B    Makefile
npm notice 2.6kB  README.markdown
npm notice 15.4kB build/index.js
npm notice 10.9kB build/index.js.map
npm notice 333B   bump.sh
npm notice 460B   integration/graphql-codegen.yml
npm notice 432B   integration/schema/books.graphql
npm notice 482B   integration/schema/schema.graphql
npm notice 54B    integration/src/context.ts
npm notice 2.7kB  integration/src/generated/graphql-types.ts
npm notice 528B   integration/src/resolvers/index.ts
npm notice 505B   integration/src/resolvers/mutations/books/saveBookResolver.test.ts
npm notice 213B   integration/src/resolvers/mutations/books/saveBookResolver.ts
npm notice 440B   integration/src/resolvers/mutations/index.ts
npm notice 510B   integration/src/resolvers/mutations/noInputMutationResolver.test.ts
npm notice 234B   integration/src/resolvers/mutations/noInputMutationResolver.ts
npm notice 515B   integration/src/resolvers/mutations/saveAuthorResolver.test.ts
npm notice 219B   integration/src/resolvers/mutations/saveAuthorResolver.ts
npm notice 101B   integration/src/resolvers/objects/authorResolvers.test.ts
npm notice 146B   integration/src/resolvers/objects/authorResolvers.ts
npm notice 99B    integration/src/resolvers/objects/books/bookResolvers.test.ts
npm notice 140B   integration/src/resolvers/objects/books/bookResolvers.ts
npm notice 267B   integration/src/resolvers/objects/index.ts
npm notice 489B   integration/src/resolvers/queries/authorsResolver.test.ts
npm notice 204B   integration/src/resolvers/queries/authorsResolver.ts
npm notice 405B   integration/src/resolvers/queries/books/booksResolver.test.ts
npm notice 198B   integration/src/resolvers/queries/books/booksResolver.ts
npm notice 304B   integration/src/resolvers/queries/index.ts
npm notice 489B   integration/src/resolvers/subscriptions/authorSavedResolver.test.ts
npm notice 422B   integration/src/resolvers/subscriptions/authorSavedResolver.ts
npm notice 586B   integration/src/resolvers/subscriptions/books/bookSavedResolver.test.ts
npm notice 705B   integration/src/resolvers/subscriptions/books/bookSavedResolver.ts
npm notice 361B   integration/src/resolvers/subscriptions/index.ts
npm notice 227B   integration/src/resolvers/testUtils.ts
npm notice 369B   integration/tsconfig.json
npm notice 1.1kB  package.json
npm notice 301B   tsconfig.json
npm notice === Tarball Details ===
npm notice name:          @homebound/graphql-typescript-resolver-scaffolding
npm notice version:       1.0.0-bump
npm notice filename:      @homebound/graphql-typescript-resolver-scaffolding-1.0.0-bump.tgz
npm notice package size:  10.7 kB
npm notice unpacked size: 43.5 kB
npm notice shasum:        ea21e2ce353a28b86951227d45e29cd70834946a
npm notice integrity:     sha512-9EFIOFTjpzMAn[...]EIN5NQ1g4L2uA==
npm notice total files:   39
npm notice
homebound-graphql-typescript-resolver-scaffolding-1.0.0-bump.tgz
```

Now:

```
 ~/code/homebound/graphql-typescript-resolver-scaffolding   fix/exclude-integration-from-npm-package  npm pack
npm notice
npm notice 📦  @homebound/graphql-typescript-resolver-scaffolding@1.0.0-bump
npm notice === Tarball Contents ===
npm notice 9B     .nvmrc
npm notice 65B    .prettierrc.js
npm notice 49B    Makefile
npm notice 2.6kB  README.markdown
npm notice 15.4kB build/index.js
npm notice 10.9kB build/index.js.map
npm notice 333B   bump.sh
npm notice 10.7kB homebound-graphql-typescript-resolver-scaffolding-1.0.0-bump.tgz
npm notice 1.1kB  package.json
npm notice 301B   tsconfig.json
npm notice === Tarball Details ===
npm notice name:          @homebound/graphql-typescript-resolver-scaffolding
npm notice version:       1.0.0-bump
npm notice filename:      @homebound/graphql-typescript-resolver-scaffolding-1.0.0-bump.tgz
npm notice package size:  19.6 kB
npm notice unpacked size: 41.4 kB
npm notice shasum:        aeab4718007666182b8111fee19cea37e63bd641
npm notice integrity:     sha512-HWfj22ciQLIR5[...]NNdXiDO9Z3HoA==
npm notice total files:   10
npm notice
homebound-graphql-typescript-resolver-scaffolding-1.0.0-bump.tgz
```